### PR TITLE
Specify full golang toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/embrace-io/s3-batch-object-store
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.0


### PR DESCRIPTION
CodeQL is [warning](https://github.com/embrace-io/s3-batch-object-store/security/code-scanning/tools/CodeQL/status/configurations/automatic) about:
> As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
> 1.22 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.