### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/embrace-io/s3-batch-object-store/security/code-scanning/3](https://github.com/embrace-io/s3-batch-object-store/security/code-scanning/3)

To fix the problem, add a `permissions` block to restrict the GitHub Actions token to the minimal required access level. Given that the workflow only reads code (for checkout and testing), you should specify `contents: read` at the workflow or job level. The best way to do this is to add the following YAML snippet at the top level, directly after the `name:` block and before the `on:` block, unless more granular permissions are needed for specific jobs (which does not appear to be the case here). No additional imports, methods, or further configuration is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
